### PR TITLE
added support for custom openai api

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -13,6 +13,7 @@ services:
       - SERPER_API_KEY=${SERPER_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - CUSTOM_HOST=${CUSTOM_HOST:-http://host.docker.internal:1234/v1}
+      - CUSTOM_API_KEY=${CUSTOM_API_KEY}
       - GROQ_API_KEY=${GROQ_API_KEY}
       - ENABLE_LOCAL_MODELS=${ENABLE_LOCAL_MODELS:-True}
       - SEARCH_PROVIDER=${SEARCH_PROVIDER:-tavily}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -12,6 +12,7 @@ services:
       - BING_API_KEY=${BING_API_KEY}
       - SERPER_API_KEY=${SERPER_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - CUSTOM_HOST=${CUSTOM_HOST:-http://host.docker.internal:1234/v1}
       - GROQ_API_KEY=${GROQ_API_KEY}
       - ENABLE_LOCAL_MODELS=${ENABLE_LOCAL_MODELS:-True}
       - SEARCH_PROVIDER=${SEARCH_PROVIDER:-tavily}

--- a/src/backend/chat.py
+++ b/src/backend/chat.py
@@ -60,6 +60,11 @@ def get_llm(model: ChatModel) -> LLM:
         )
     elif model == ChatModel.LLAMA_3_70B:
         return Groq(model=model_mappings[model])
+    elif model == ChatModel.CUSTOM:
+        return OpenAI(model=model_mappings[model], # can use https://docs.llamaindex.ai/en/stable/api_reference/llms/openai_like/ instead
+                      api_base=os.environ.get("CUSTOM_HOST", "http://localhost:1234/v1"),
+                      api_key=os.environ.get("CUSTOM_API_KEY", "custom-key")  
+        )
     else:
         raise ValueError(f"Unknown model: {model}")
 

--- a/src/backend/constants.py
+++ b/src/backend/constants.py
@@ -9,6 +9,7 @@ LOCAL_LLAMA3_MODEL = "llama3"
 LOCAL_GEMMA_MODEL = "gemma:7b"
 LOCAL_MISTRAL_MODEL = "mistral"
 LOCAL_PHI3_14B = "phi3:14b"
+CUSTOM_MODEL = "gpt-4" # llama_index really wants to know model context length so 8k by default.
 
 
 class ChatModel(str, Enum):
@@ -21,6 +22,7 @@ class ChatModel(str, Enum):
     LOCAL_GEMMA = "gemma"
     LOCAL_MISTRAL = "mistral"
     LOCAL_PHI3_14B = "phi3:14b"
+    CUSTOM = "custom-api"
 
 
 model_mappings: dict[ChatModel, str] = {
@@ -31,4 +33,5 @@ model_mappings: dict[ChatModel, str] = {
     ChatModel.LOCAL_GEMMA: LOCAL_GEMMA_MODEL,
     ChatModel.LOCAL_MISTRAL: LOCAL_MISTRAL_MODEL,
     ChatModel.LOCAL_PHI3_14B: LOCAL_PHI3_14B,
+    ChatModel.CUSTOM: CUSTOM_MODEL,
 }

--- a/src/backend/related_queries.py
+++ b/src/backend/related_queries.py
@@ -36,6 +36,14 @@ def instructor_client(model: ChatModel) -> instructor.AsyncInstructor:
         )
     elif model == ChatModel.LLAMA_3_70B:
         return instructor.from_groq(groq.AsyncGroq(), mode=instructor.Mode.JSON)
+    elif model == ChatModel.CUSTOM:
+        return instructor.from_openai(
+            openai.AsyncOpenAI(
+                base_url=os.environ.get("CUSTOM_HOST", "http://localhost:1234/v1"),
+                api_key=os.environ.get("CUSTOM_API_KEY", "custom-key")
+            ),
+            mode=instructor.Mode.JSON,
+        )
     else:
         raise ValueError(f"Unknown model: {model}")
 

--- a/src/backend/validators.py
+++ b/src/backend/validators.py
@@ -24,6 +24,10 @@ def validate_model(model: ChatModel):
         LOCAL_MODELS_ENABLED = strtobool(os.getenv("ENABLE_LOCAL_MODELS", False))
         if not LOCAL_MODELS_ENABLED:
             raise ValueError("Local models are not enabled")
+    elif model == ChatModel.CUSTOM:
+        CUSTOM_HOST = os.getenv("CUSTOM_HOST")
+        if not CUSTOM_HOST:
+            raise ValueError("CUSTOM_HOST environment variable not found")
     else:
         raise ValueError("Invalid model")
     return True

--- a/src/frontend/generated/types.gen.ts
+++ b/src/frontend/generated/types.gen.ts
@@ -13,6 +13,7 @@ export enum ChatModel {
   GEMMA = "gemma",
   MISTRAL = "mistral",
   LOCAL_PHI3_14B = "phi3:14b",
+  CUSTOM = "custom-api",
 }
 
 export type ChatRequest = {

--- a/src/frontend/src/components/model-selection.tsx
+++ b/src/frontend/src/components/model-selection.tsx
@@ -82,6 +82,13 @@ const modelMap: Record<ChatModel, Model> = {
     smallIcon: <FlameIcon className="w-4 h-4 text-green-500" />,
     icon: <FlameIcon className="w-5 h-5 text-green-500" />,
   },
+  [ChatModel.CUSTOM]: {
+    name: "Custom API",
+    description: "Custom API",
+    value: ChatModel.CUSTOM,
+    smallIcon: <MagicWandIcon className="w-4 h-4 text-[#FF0080]" />,
+    icon: <MagicWandIcon className="w-5 h-5 text-[#FF0080]" />,
+  },
 };
 
 const localModelMap: Partial<Record<ChatModel, Model>> = _.pickBy(


### PR DESCRIPTION
Support for a custom openai api, using default llama_index.llms.openai (no requirement change)

- https://github.com/rashadphz/farfalle/issues/39#issue-2328272477
- https://github.com/rashadphz/farfalle/issues/1#issue-2302369769

 ### backend:
- created "CUSTOM" model mapping with "gpt-4" as its name for llama_index to use 8k context.
- added elif statement to chat, related queries and validator for ChatModel.CUSTOM

### frontend:
- added Custom API as selectable model.

### docker:
- added `CUSTOM_HOST` and `CUSTOM_API_KEY` env variables with lm-studio url set by default (http://localhost:1234/v1)

enviromental variables:
```
CUSTOM_HOST=your-custom-host
CUSTOM_API_KEY=your-custom-api-key
```
.env example for lm-studio server:
```
CUSTOM_HOST=http://localhost:1234/v1
CUSTOM_API_KEY=local
```
_api-key in most cases is not nedded._

### why use custom instead of openai naming?
llama_index uses OPENAI_API_BASE while openai uses OPENAI_BASE_URL
adding the new variable make sure it does not conflict with cloud openai usage.

### tested with lm-studio local server using: 
- llama3 8B (also some finetunes versions like Herme 2 Theta)
- mistral v0.3 7B
- phi 3 mini

### preview:
![Captura de pantalla 2024-06-02 220940](https://github.com/rashadphz/farfalle/assets/89663273/a3d38eef-b2d5-47d4-8833-9c245db5d366)
