### PR TITLE
exclude files from ide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 .vscode
 .history
+.favorites.json
 
 # Distribution / packaging
 .Python

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.so
 
 .vscode
+.history
 
 # Distribution / packaging
 .Python


### PR DESCRIPTION
- This avoids the directory `.history` to truck from the VS Code extension [Local History](https://marketplace.visualstudio.com/items?itemName=xyz.local-history).
- This avoids the file `.favorites.json` to truck from the VS Code extension [Favorites](https://marketplace.visualstudio.com/items?itemName=howardzuo.vscode-favorites#:~:text=An%20extension%20that%20lets%20the,they%20can%20be%20easily%20accessed.).