### PR TITLE
fix(issue-89): workaround for unmarshalling-strings issue 

### DIFF
--- a/src/backend/related_queries.py
+++ b/src/backend/related_queries.py
@@ -1,15 +1,20 @@
 from backend.llm.base import BaseLLM
 from backend.prompts import RELATED_QUESTION_PROMPT
 from backend.schemas import RelatedQueries, SearchResult
-
+import ast 
 
 async def generate_related_queries(
     query: str, search_results: list[SearchResult], llm: BaseLLM
 ) -> list[str]:
     context = "\n\n".join([f"{str(result)}" for result in search_results])
     context = context[:4000]
+
     related = llm.structured_complete(
         RelatedQueries, RELATED_QUESTION_PROMPT.format(query=query, context=context)
     )
 
-    return [query.lower().replace("?", "") for query in related.related_questions]
+    # Hotfix Part II (https://github.com/rashadphz/farfalle/issues/82)
+    if len(related.related_questions) == 1:
+        related.related_questions = ast.literal_eval(related.related_questions[0])
+
+    return [query.lower().replace("?", "").replace("}", "") for query in related.related_questions]

--- a/src/backend/schemas.py
+++ b/src/backend/schemas.py
@@ -7,7 +7,7 @@ from typing import List, Union
 
 from dotenv import load_dotenv
 from logfire.integrations.pydantic import PluginSettings
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, BaseConfig, validator
 
 from backend.constants import ChatModel
 from backend.utils import strtobool
@@ -39,9 +39,15 @@ class ChatRequest(BaseModel, plugin_settings=record_all):
     pro_search: bool = False
 
 
+# Hotfix Part I (https://github.com/rashadphz/farfalle/issues/82)
 class RelatedQueries(BaseModel):
-    related_questions: List[str] = Field(..., min_length=3, max_length=3)
+    related_questions: List[str] 
 
+    @validator('related_questions', pre=True)
+    def ensure_list(cls, v):
+        if isinstance(v, str):
+            return [v]
+        return v
 
 class SearchResult(BaseModel):
     title: str
@@ -183,6 +189,9 @@ class ChatSnapshot(BaseModel):
     date: datetime
     preview: str
     model_name: str
+
+    class Config(BaseConfig):
+        protected_namespaces = ()
 
 
 class ChatHistoryResponse(BaseModel):


### PR DESCRIPTION
Found a workaround to fix the issue... give it a try. Could not find the root-cause yet. 
Fixes https://github.com/rashadphz/farfalle/issues/89 by reducing the strictness of the pydantic validation of the litellm output (part 1), detecting the workaround later and resolving it for the rest of the later pipeline (part 2). 

Also fixed a warning for protected_namespaces. 

Possibly also fixing https://github.com/rashadphz/farfalle/issues/59? Could not reproduce. 