### PR TITLE
fix: resolve Docker Poetry README.md issue (#108)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Rashad Philizaire <rashadphilizaire@gmail.com>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -16,6 +16,9 @@ WORKDIR /workspace
 # Copy dependency files to avoid cache invalidations
 COPY pyproject.toml poetry.lock ./
 
+# Copy README.md for Poetry packaging
+COPY README.md ./
+
 COPY src/backend/ src/backend/
 
 RUN pip install --no-cache-dir poetry && poetry install

--- a/standalone.Dockerfile
+++ b/standalone.Dockerfile
@@ -37,6 +37,9 @@ WORKDIR /workspace
 # Copy dependency files to avoid cache invalidations
 COPY pyproject.toml poetry.lock ./
 
+# Copy README.md for Poetry packaging
+COPY README.md ./
+
 # Install dependencies
 RUN poetry install
 


### PR DESCRIPTION
(fixes #108 )
- Add README.md copy to backend Dockerfile for Poetry packaging
- Add README.md copy to standalone Dockerfile for Poetry packaging
- Fixes 'Readme path /workspace/README.md does not exist' error
- Resolves Docker installation failures during poetry install