### PR TITLE
feat(frontend): Add GFM table support in markdown rendering

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -45,6 +45,7 @@
     "react-markdown": "^9.0.1",
     "react-textarea-autosize": "^8.5.3",
     "rehype-raw": "^7.0.0",
+    "remark-gfm": "^4.0.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "unist-util-visit": "^5.0.0",

--- a/src/frontend/src/components/message.tsx
+++ b/src/frontend/src/components/message.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo, useEffect, useMemo, useState } from "react";
 import { MemoizedReactMarkdown } from "./markdown";
 import rehypeRaw from "rehype-raw";
+import remarkGfm from "remark-gfm";
 
 import _ from "lodash";
 import { cn } from "@/lib/utils";
@@ -110,10 +111,53 @@ const StreamingListItem = memo(
   },
 );
 
+// Table components for GFM markdown support
+const Table = memo(({ children }: React.HTMLProps<HTMLTableElement>) => (
+  <div className="overflow-x-auto my-4">
+    <table className="min-w-full border-collapse border border-border">
+      {children}
+    </table>
+  </div>
+));
+
+const TableHead = memo(
+  ({ children }: React.HTMLProps<HTMLTableSectionElement>) => (
+    <thead className="bg-muted">{children}</thead>
+  ),
+);
+
+const TableBody = memo(
+  ({ children }: React.HTMLProps<HTMLTableSectionElement>) => (
+    <tbody>{children}</tbody>
+  ),
+);
+
+const TableRow = memo(({ children }: React.HTMLProps<HTMLTableRowElement>) => (
+  <tr className="border-b border-border">{children}</tr>
+));
+
+const TableHeader = memo(
+  ({ children }: React.HTMLProps<HTMLTableCellElement>) => (
+    <th className="px-4 py-2 text-left font-semibold border border-border">
+      {children}
+    </th>
+  ),
+);
+
+const TableCell = memo(({ children }: React.HTMLProps<HTMLTableCellElement>) => (
+  <td className="px-4 py-2 border border-border">{children}</td>
+));
+
 StreamingParagraph.displayName = "StreamingParagraph";
 Paragraph.displayName = "Paragraph";
 ListItem.displayName = "ListItem";
 StreamingListItem.displayName = "StreamingListItem";
+Table.displayName = "Table";
+TableHead.displayName = "TableHead";
+TableBody.displayName = "TableBody";
+TableRow.displayName = "TableRow";
+TableHeader.displayName = "TableHeader";
+TableCell.displayName = "TableCell";
 
 export const MessageComponent: FC<MessageProps> = ({
   message,
@@ -145,8 +189,21 @@ export const MessageComponent: FC<MessageProps> = ({
         p: isStreaming ? StreamingParagraph : Paragraph,
         // @ts-ignore
         li: isStreaming ? StreamingListItem : ListItem,
+        // @ts-ignore
+        table: Table,
+        // @ts-ignore
+        thead: TableHead,
+        // @ts-ignore
+        tbody: TableBody,
+        // @ts-ignore
+        tr: TableRow,
+        // @ts-ignore
+        th: TableHeader,
+        // @ts-ignore
+        td: TableCell,
       }}
       className="prose dark:prose-invert inline leading-relaxed break-words "
+      remarkPlugins={[remarkGfm]}
       rehypePlugins={[rehypeRaw]}
     >
       {parsedMessage}


### PR DESCRIPTION
## Summary

Add remark-gfm plugin to enable GitHub Flavored Markdown tables in chat responses. Without this, tables render as raw text on a single line instead of formatted tables.

## Changes

- Add `remark-gfm` dependency to package.json
- Add Table, TableHead, TableBody, TableRow, TableHeader, TableCell components with proper styling using existing theme variables (border-border, bg-muted)
- Register `remarkGfm` plugin in MemoizedReactMarkdown

## Test plan

- [x] Ask a question that generates a table response
- [x] Verify table renders with proper borders and styling
- [x] Verify existing markdown (paragraphs, lists, citations) still works

## Screenshots

Before: Tables render as `| Col1 | Col2 | |---|---| | val1 | val2 |` on single line

After: Tables render as proper HTML tables with borders and styling